### PR TITLE
Update async_std version to include regression fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "async-file-benchmark"
 version = "0.1.0"
 dependencies = [
- "async-std 0.99.12 (git+https://github.com/async-rs/async-std)",
+ "async-std 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.0-alpha.6 (git+https://github.com/tokio-rs/tokio)",
@@ -34,8 +34,8 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "0.99.12"
-source = "git+https://github.com/async-rs/async-std#122e87364bef463c5afbf7681ec3ce35a3a7f577"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-macros 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-task 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -722,7 +722,7 @@ dependencies = [
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum arc-swap 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f1a1eca3195b729bbd64e292ef2f5fff6b1c28504fed762ce2b1013dde4d8e92"
 "checksum async-macros 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e421d59b24c1feea2496e409b3e0a8de23e5fc130a2ddc0b012e551f3b272bba"
-"checksum async-std 0.99.12 (git+https://github.com/async-rs/async-std)" = "<none>"
+"checksum async-std 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6ee33a6cfdd96bfde032d14b29905244a70868bd8dda1f3b13504d6cbc3b7bc"
 "checksum async-task 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de6bd58f7b9cc49032559422595c81cbfcf04db2f2133592f70af19e258a1ced"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-#async-std = "=0.99.10"
-async-std = { git = "https://github.com/async-rs/async-std", branch = "master" }
+async-std = "1.0.1"
 futures-preview = "=0.3.0-alpha.19"
 #tokio = "=0.2.0-alpha.6"
 tokio = { git = "https://github.com/tokio-rs/tokio", branch = "master" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,7 @@ fn main() {
     describe_header();
 
     // Real thing
-    tokio_rt.block_on(run_benchmark(read_file_tokio, Some("tokio\t"), 5000));
     async_std::task::block_on(run_benchmark(read_file_async_std, Some("async-std"), 5000));
+    tokio_rt.block_on(run_benchmark(read_file_tokio, Some("tokio\t"), 5000));
+
 }


### PR DESCRIPTION
This PR includes items from async-std version 1.0.1, namely https://github.com/async-rs/async-std/pull/510.

This PR also moves async-std execution to be first, mostly for testing purposes.

I now see results that look roughly as such:

```
runtime		time per
async-std	0.754
tokio		2.945
```