### PR TITLE
Minimized allocations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,25 +35,18 @@ const FILE_SIZE: usize = 256 * 1024;
 // async-std, and tokio all use a 8192-byte buffer.
 const BUF_SIZE: usize = 2048;
 
-async fn discard<T>(_x: T) {
-    // TODO: this should probably be a black-box
-}
-
 async fn read_file_async_std() -> Result<(), Box<dyn Error>> {
     use async_std::prelude::*;
 
     let mut file = async_std::fs::File::open("file.dat").await?;
     let mut total_read = 0;
+    let mut buf = [0; BUF_SIZE];
     loop {
-        let mut buf = vec![0; BUF_SIZE];
-        match file.read(&mut buf).await {
-            Ok(n) if n == 0 => break,
-            Ok(n) => {
-                buf.truncate(n);
+        match file.read(&mut buf).await? {
+            0 => break,
+            n => {
                 total_read += n;
-                discard(buf).await;
             }
-            Err(e) => return Err(e)?,
         }
     }
 
@@ -67,16 +60,13 @@ async fn read_file_tokio() -> Result<(), Box<dyn Error>> {
 
     let mut file = tokio::fs::File::open("file.dat").await?;
     let mut total_read = 0;
+    let mut buf = [0; BUF_SIZE];
     loop {
-        let mut buf = vec![0; BUF_SIZE];
-        match file.read(&mut buf).await {
-            Ok(n) if n == 0 => break,
-            Ok(n) => {
-                buf.truncate(n);
+        match file.read(&mut buf).await? {
+            0 => break,
+            n => {
                 total_read += n;
-                discard(buf).await;
             }
-            Err(e) => return Err(e)?,
         }
     }
 


### PR DESCRIPTION
The original results on my laptop:

```
runtime         time per
async-std       0.980
tokio           3.499
async-std       0.749
tokio           3.506
async-std       0.760
tokio           3.729
async-std       0.776
tokio           3.551
async-std       0.734
tokio           3.441
async-std       0.757
tokio           3.455
```

The new results:

```
runtime         time per
async-std       0.831
tokio           3.340
async-std       0.575
tokio           3.306
async-std       0.564
tokio           3.351
async-std       0.687
tokio           3.467
async-std       0.570
tokio           3.356
async-std       0.557
tokio           3.354
```

NOTE: It does not solve the oddity of tokio I observe in https://github.com/jebrosen/async-file-benchmark/issues/3#issuecomment-552805870